### PR TITLE
PCC-26 Enable CORS in devel mode

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,6 +12,8 @@ cron.expr=0 0 0 * * ?
 
 quarkus.http.root-path=/v1
 
+%dev.quarkus.http.cors=true
+
 # flyway
 quarkus.flyway.migrate-at-start=true
 quarkus.flyway.baseline-on-migrate=true


### PR DESCRIPTION
Quickly enable CORS in `%dev` mode (will help while developing and testing the UI as well). This is in a preliminary manner will tweak the detailed settings later