### PR TITLE
PCC-57 Extend prefix model with lookup service type information

### DIFF
--- a/src/main/java/gr/grnet/pccapi/dto/PartialPrefixDto.java
+++ b/src/main/java/gr/grnet/pccapi/dto/PartialPrefixDto.java
@@ -1,6 +1,7 @@
 package gr.grnet.pccapi.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import gr.grnet.pccapi.enums.LookUpServiceType;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -29,6 +30,14 @@ public class PartialPrefixDto {
       example = "1")
   @JsonProperty("service_id")
   public Integer serviceId;
+
+  @Schema(
+      type = SchemaType.STRING,
+      implementation = LookUpServiceType.class,
+      description = "The type of lookup service the prefix supports",
+      example = "PRIVATE")
+  @JsonProperty("lookup_service_type")
+  public LookUpServiceType lookUpServiceType;
 
   @Schema(
       type = SchemaType.INTEGER,

--- a/src/main/java/gr/grnet/pccapi/dto/PrefixDto.java
+++ b/src/main/java/gr/grnet/pccapi/dto/PrefixDto.java
@@ -1,6 +1,7 @@
 package gr.grnet.pccapi.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import gr.grnet.pccapi.enums.LookUpServiceType;
 import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
@@ -21,6 +22,15 @@ public class PrefixDto {
   public String usedBy;
 
   @NotNull public Integer status;
+
+  @Schema(
+      type = SchemaType.STRING,
+      implementation = LookUpServiceType.class,
+      description = "The type of lookup service the prefix supports",
+      example = "PRIVATE")
+  @NotNull
+  @JsonProperty("lookup_service_type")
+  public LookUpServiceType lookUpServiceType;
 
   @Schema(
       type = SchemaType.INTEGER,

--- a/src/main/java/gr/grnet/pccapi/endpoint/ReverseLookUpEndpoint.java
+++ b/src/main/java/gr/grnet/pccapi/endpoint/ReverseLookUpEndpoint.java
@@ -4,6 +4,7 @@ import gr.grnet.pccapi.dto.APIResponseMsg;
 import gr.grnet.pccapi.dto.FiltersDto;
 import gr.grnet.pccapi.dto.HandleDto;
 import gr.grnet.pccapi.enums.Filter;
+import gr.grnet.pccapi.enums.LookUpServiceType;
 import gr.grnet.pccapi.service.ReverseLookUpService;
 import java.util.EnumSet;
 import javax.ws.rs.Consumes;
@@ -77,5 +78,20 @@ public class ReverseLookUpEndpoint {
   @Produces(MediaType.APPLICATION_JSON)
   public Response filters() {
     return Response.ok().entity(EnumSet.allOf(Filter.class)).build();
+  }
+
+  @Tag(name = "Reverse LookUp")
+  @APIResponse(
+      responseCode = "200",
+      description = "Return all the supported types.",
+      content =
+          @Content(
+              schema = @Schema(type = SchemaType.ARRAY, implementation = LookUpServiceType.class)))
+  @Operation(summary = "Get a list of all available lookup service types")
+  @GET
+  @Path("/types")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response types() {
+    return Response.ok().entity(EnumSet.allOf(LookUpServiceType.class)).build();
   }
 }

--- a/src/main/java/gr/grnet/pccapi/entity/Prefix.java
+++ b/src/main/java/gr/grnet/pccapi/entity/Prefix.java
@@ -1,8 +1,11 @@
 package gr.grnet.pccapi.entity;
 
+import gr.grnet.pccapi.enums.LookUpServiceType;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -27,6 +30,10 @@ public class Prefix extends PanacheEntityBase {
 
   @Column(name = "used_by")
   public String usedBy;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "lookup_service_type", nullable = false)
+  public LookUpServiceType lookUpServiceType;
 
   public Integer status;
 

--- a/src/main/java/gr/grnet/pccapi/enums/LookUpServiceType.java
+++ b/src/main/java/gr/grnet/pccapi/enums/LookUpServiceType.java
@@ -1,0 +1,9 @@
+package gr.grnet.pccapi.enums;
+
+/** LookUpService enum defines the type of look up service a prefix supports */
+public enum LookUpServiceType {
+  CENTRAL,
+  PRIVATE,
+  BOTH,
+  NONE
+}

--- a/src/main/java/gr/grnet/pccapi/mapper/PrefixMapper.java
+++ b/src/main/java/gr/grnet/pccapi/mapper/PrefixMapper.java
@@ -55,5 +55,9 @@ public interface PrefixMapper {
       target = "status",
       expression =
           "java(prefixDto.status != null ? Integer.parseInt(prefixDto.status) : prefix.status)")
+  @Mapping(
+      target = "lookUpServiceType",
+      expression =
+          "java(prefixDto.lookUpServiceType != null ? prefixDto.lookUpServiceType : prefix.lookUpServiceType)")
   void updatePrefixFromDto(PartialPrefixDto prefixDto, @MappingTarget Prefix prefix);
 }

--- a/src/main/java/gr/grnet/pccapi/service/PrefixService.java
+++ b/src/main/java/gr/grnet/pccapi/service/PrefixService.java
@@ -67,6 +67,7 @@ public class PrefixService {
             .setService(service)
             .setDomain(domain)
             .setProvider(provider)
+            .setLookUpServiceType(prefixDto.getLookUpServiceType())
             .setOwner(prefixDto.getOwner())
             .setName(prefixDto.getName())
             .setUsedBy(prefixDto.getUsedBy())
@@ -186,13 +187,18 @@ public class PrefixService {
         providerRepository
             .findByIdOptional(prefixDto.getProviderId())
             .orElseThrow(() -> new NotFoundException("Provider not found"));
-    // retrieve the prefix
+
+    // check the uniqueness of the provided name
+    if (prefixRepository.existsByName(prefixDto.getName())) {
+      throw new ConflictException("Prefix name already exists");
+    }
 
     // update the prefix
     prefix.setService(service);
     prefix.setProvider(provider);
     prefix.setDomain(domain);
     prefix.setStatus(prefixDto.status);
+    prefix.setLookUpServiceType(prefixDto.lookUpServiceType);
     prefix.setOwner(prefixDto.owner);
     prefix.setUsedBy(prefixDto.usedBy);
     prefix.setName(prefixDto.name);

--- a/src/main/resources/db/migration/V1.4__prefix_lookup_service.sql
+++ b/src/main/resources/db/migration/V1.4__prefix_lookup_service.sql
@@ -1,0 +1,13 @@
+-- ------------------------------------------------
+-- Version: v1.4
+--
+-- Description: Migration that introduces the prefix lookup_service_type field which is
+--  an enum that indicates which hrls service to use.
+-- CENTRAL -> is for looking up the prefix in the central service
+-- PRIVATE -> is for looking up the prefix in its own service
+-- BOTH -> means that the service supports both central and private
+-- NONE -> supports no lookup service
+-- @author: Agelos Tsalapatis
+-- -------------------------------------------------
+
+ALTER TABLE prefix ADD COLUMN lookup_service_type ENUM('CENTRAL', 'PRIVATE', 'BOTH', 'NONE') NOT NULL DEFAULT 'CENTRAL';

--- a/src/test/java/gr/grnet/pccapi/PrefixEndpointTest.java
+++ b/src/test/java/gr/grnet/pccapi/PrefixEndpointTest.java
@@ -8,6 +8,7 @@ import gr.grnet.pccapi.dto.PartialPrefixDto;
 import gr.grnet.pccapi.dto.PrefixDto;
 import gr.grnet.pccapi.dto.PrefixResponseDto;
 import gr.grnet.pccapi.endpoint.PrefixEndpoint;
+import gr.grnet.pccapi.enums.LookUpServiceType;
 import gr.grnet.pccapi.repository.DomainRepository;
 import gr.grnet.pccapi.repository.PrefixRepository;
 import gr.grnet.pccapi.repository.ProviderRepository;
@@ -48,6 +49,7 @@ public class PrefixEndpointTest {
             .setOwner("someone")
             .setStatus(2)
             .setUsedBy("someone else")
+            .setLookUpServiceType(LookUpServiceType.PRIVATE)
             .setDomainId(1)
             .setServiceId(1)
             .setProviderId(1);
@@ -67,6 +69,7 @@ public class PrefixEndpointTest {
     assertEquals("11523", response.getName());
     assertEquals("someone", response.getOwner());
     assertEquals("someone else", response.getUsedBy());
+    assertEquals(LookUpServiceType.PRIVATE, response.getLookUpServiceType());
     assertEquals(2, response.getStatus());
     assertEquals("Medical & Health Sciences", response.getDomainName());
     assertEquals(1, response.getDomainId());
@@ -85,6 +88,7 @@ public class PrefixEndpointTest {
             .setOwner("someone")
             .setStatus(2)
             .setUsedBy("someone else")
+            .setLookUpServiceType(LookUpServiceType.PRIVATE)
             .setDomainId(1)
             .setServiceId(1)
             .setProviderId(1);
@@ -195,6 +199,7 @@ public class PrefixEndpointTest {
             .setOwner("someone")
             .setStatus(2)
             .setUsedBy("someone else")
+            .setLookUpServiceType(LookUpServiceType.NONE)
             .setDomainId(1)
             .setServiceId(1)
             .setProviderId(1);
@@ -216,6 +221,7 @@ public class PrefixEndpointTest {
             .setOwner("someone1")
             .setStatus(3)
             .setUsedBy("someone else1")
+            .setLookUpServiceType(LookUpServiceType.PRIVATE)
             .setDomainId(2)
             .setServiceId(2)
             .setProviderId(2);
@@ -237,6 +243,7 @@ public class PrefixEndpointTest {
 
     assertEquals("someone1", response.getOwner());
     assertEquals("someone else1", response.getUsedBy());
+    assertEquals(LookUpServiceType.PRIVATE, response.getLookUpServiceType());
 
     assertEquals(3, response.getStatus());
     assertEquals("77777", response.getName());
@@ -252,6 +259,7 @@ public class PrefixEndpointTest {
             .setOwner("someone")
             .setStatus(2)
             .setUsedBy("someone else")
+            .setLookUpServiceType(LookUpServiceType.PRIVATE)
             .setDomainId(1)
             .setServiceId(1)
             .setProviderId(1);
@@ -289,6 +297,7 @@ public class PrefixEndpointTest {
             .setOwner("someone")
             .setStatus(2)
             .setUsedBy("someone else")
+            .setLookUpServiceType(LookUpServiceType.PRIVATE)
             .setDomainId(1)
             .setServiceId(1)
             .setProviderId(1);
@@ -319,6 +328,7 @@ public class PrefixEndpointTest {
             .setOwner("someone")
             .setStatus(2)
             .setUsedBy("someone else")
+            .setLookUpServiceType(LookUpServiceType.PRIVATE)
             .setDomainId(1)
             .setServiceId(1)
             .setProviderId(1);
@@ -357,6 +367,7 @@ public class PrefixEndpointTest {
             .setOwner("someone")
             .setStatus(2)
             .setUsedBy("someone else")
+            .setLookUpServiceType(LookUpServiceType.BOTH)
             .setDomainId(1)
             .setServiceId(1)
             .setProviderId(1);
@@ -384,6 +395,7 @@ public class PrefixEndpointTest {
     assertEquals(created.name, prefixResponseDto.name);
     assertEquals(created.domainId, prefixResponseDto.domainId);
     assertEquals(created.id, prefixResponseDto.id);
+    assertEquals(created.lookUpServiceType, prefixResponseDto.lookUpServiceType);
   }
 
   @Test
@@ -420,6 +432,7 @@ public class PrefixEndpointTest {
             .setOwner("someone")
             .setStatus(2)
             .setUsedBy("someone else")
+            .setLookUpServiceType(LookUpServiceType.CENTRAL)
             .setDomainId(1)
             .setServiceId(1)
             .setProviderId(1);
@@ -435,7 +448,11 @@ public class PrefixEndpointTest {
             .extract()
             .as(PrefixResponseDto.class);
 
-    var patchRequestBody = new PartialPrefixDto().setName("222222").setDomainId(2);
+    var patchRequestBody =
+        new PartialPrefixDto()
+            .setName("222222")
+            .setLookUpServiceType(LookUpServiceType.PRIVATE)
+            .setDomainId(2);
 
     var patchResponse =
         given()
@@ -450,6 +467,7 @@ public class PrefixEndpointTest {
 
     assertEquals(patchRequestBody.name, patchResponse.name);
     assertEquals(patchRequestBody.domainId, patchResponse.domainId);
+    assertEquals(patchRequestBody.lookUpServiceType, patchResponse.lookUpServiceType);
   }
 
   @Test
@@ -461,6 +479,7 @@ public class PrefixEndpointTest {
             .setOwner("someone")
             .setStatus(2)
             .setUsedBy("someone else")
+            .setLookUpServiceType(LookUpServiceType.PRIVATE)
             .setDomainId(1)
             .setServiceId(1)
             .setProviderId(1);
@@ -502,6 +521,7 @@ public class PrefixEndpointTest {
             .setOwner("someone")
             .setStatus(2)
             .setUsedBy("someone else")
+            .setLookUpServiceType(LookUpServiceType.PRIVATE)
             .setDomainId(1)
             .setServiceId(1)
             .setProviderId(1);

--- a/src/test/java/gr/grnet/pccapi/ReverseLookupEndpointTest.java
+++ b/src/test/java/gr/grnet/pccapi/ReverseLookupEndpointTest.java
@@ -151,4 +151,23 @@ public class ReverseLookupEndpointTest {
     assertEquals("EMAIL", response[1]);
     assertEquals("RETRIEVE_RECORDS", response[2]);
   }
+
+  @Test
+  public void testTypesSuccess() {
+    var response =
+        given()
+            .contentType(ContentType.JSON)
+            .get("/types")
+            .then()
+            .assertThat()
+            .statusCode(200)
+            .extract()
+            .as(String[].class);
+
+    assertEquals(4, response.length);
+    assertEquals("CENTRAL", response[0]);
+    assertEquals("PRIVATE", response[1]);
+    assertEquals("BOTH", response[2]);
+    assertEquals("NONE", response[3]);
+  }
 }


### PR DESCRIPTION
Add a new field lookup_service_type that will hold a value of
either central, private, both, none that will indicate what the this specific prefix supports, in terms of reverse look up fucntionality.

Add a new migration that will alter the prefix table.

Modify the logic in all prefix CRUD operations to support the newly added field.

Also add a supplementary api call GET @/reverse-lookup/types that indicates the supported service types a prefix can have.