### PR TITLE
PCC-104 Add contract-enddate to prefix

### DIFF
--- a/api/src/main/java/gr/grnet/pccapi/dto/PartialPrefixDto.java
+++ b/api/src/main/java/gr/grnet/pccapi/dto/PartialPrefixDto.java
@@ -23,6 +23,9 @@ public class PartialPrefixDto {
   @JsonProperty("used_by")
   public String usedBy;
 
+  @JsonProperty("contract_end")
+  public String contractEnd;
+
   public String status;
 
   @Schema(

--- a/api/src/main/java/gr/grnet/pccapi/dto/PrefixDto.java
+++ b/api/src/main/java/gr/grnet/pccapi/dto/PrefixDto.java
@@ -23,6 +23,9 @@ public class PrefixDto {
   @JsonProperty("used_by")
   public String usedBy;
 
+  @JsonProperty("contract_end")
+  public String contractEnd;
+
   @NotNull public Integer status;
 
   @Schema(

--- a/api/src/main/java/gr/grnet/pccapi/endpoint/PrefixEndpoint.java
+++ b/api/src/main/java/gr/grnet/pccapi/endpoint/PrefixEndpoint.java
@@ -7,6 +7,7 @@ import gr.grnet.pccapi.dto.PrefixResponseDto;
 import gr.grnet.pccapi.dto.ProviderResponseDTO;
 import gr.grnet.pccapi.service.PrefixService;
 import gr.grnet.pccapi.service.StatisticsService;
+import java.text.ParseException;
 import javax.validation.Valid;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -67,7 +68,8 @@ public class PrefixEndpoint {
               schema = @Schema(type = SchemaType.OBJECT, implementation = PrefixDto.class))
           @Valid
           @RequestBody
-          PrefixDto prefixDto) {
+          PrefixDto prefixDto)
+      throws ParseException {
     return Response.status(Response.Status.CREATED).entity(prefixService.create(prefixDto)).build();
   }
 

--- a/api/src/main/java/gr/grnet/pccapi/entity/Prefix.java
+++ b/api/src/main/java/gr/grnet/pccapi/entity/Prefix.java
@@ -2,6 +2,7 @@ package gr.grnet.pccapi.entity;
 
 import gr.grnet.pccapi.enums.LookUpServiceType;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import java.sql.Timestamp;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -36,6 +37,9 @@ public class Prefix extends PanacheEntityBase {
 
   @Column(name = "contact_email")
   public String contactEmail;
+
+  @Column(name = "contract_end")
+  public Timestamp contractEnd;
 
   @Enumerated(EnumType.STRING)
   @Column(name = "lookup_service_type", columnDefinition = "enum", nullable = false)

--- a/api/src/main/java/gr/grnet/pccapi/service/PrefixService.java
+++ b/api/src/main/java/gr/grnet/pccapi/service/PrefixService.java
@@ -13,6 +13,7 @@ import gr.grnet.pccapi.repository.DomainRepository;
 import gr.grnet.pccapi.repository.PrefixRepository;
 import gr.grnet.pccapi.repository.ProviderRepository;
 import gr.grnet.pccapi.repository.ServiceRepository;
+import java.text.ParseException;
 import java.util.List;
 import javax.enterprise.context.ApplicationScoped;
 import javax.transaction.Transactional;
@@ -35,7 +36,7 @@ public class PrefixService {
    * appropriate response dto
    */
   @Transactional
-  public PrefixResponseDto create(PrefixDto prefixDto) {
+  public PrefixResponseDto create(PrefixDto prefixDto) throws ParseException {
 
     logger.info("Inserting new prefix . . .");
 
@@ -64,20 +65,20 @@ public class PrefixService {
 
     var lookUpServiceType =
         PrefixMapper.INSTANCE.validateLookUpServiceType(prefixDto.lookUpServiceType);
+    Prefix prefix = PrefixMapper.INSTANCE.requestToPrefix(prefixDto);
 
-    Prefix prefix =
-        new Prefix()
-            .setService(service)
-            .setDomain(domain)
-            .setProvider(provider)
-            .setLookUpServiceType(lookUpServiceType)
-            .setOwner(prefixDto.getOwner())
-            .setName(prefixDto.getName())
-            .setUsedBy(prefixDto.getUsedBy())
-            .setStatus(prefixDto.getStatus())
-            .setResolvable(prefixDto.getResolvable())
-            .setContactName(prefixDto.getContactName())
-            .setContactEmail(prefixDto.getContactEmail());
+    prefix
+        .setService(service)
+        .setDomain(domain)
+        .setProvider(provider)
+        .setLookUpServiceType(lookUpServiceType)
+        .setOwner(prefixDto.getOwner())
+        .setName(prefixDto.getName())
+        .setUsedBy(prefixDto.getUsedBy())
+        .setStatus(prefixDto.getStatus())
+        .setResolvable(prefixDto.getResolvable())
+        .setContactName(prefixDto.getContactName())
+        .setContactEmail(prefixDto.getContactEmail());
 
     prefixRepository.persist(prefix);
     return PrefixMapper.INSTANCE.prefixToResponseDto(prefix);
@@ -203,9 +204,10 @@ public class PrefixService {
     if (prefixRepository.existsByName(prefixDto.getName())) {
       throw new ConflictException("Prefix name already exists");
     }
-
     var lookUpServiceType =
         PrefixMapper.INSTANCE.validateLookUpServiceType(prefixDto.lookUpServiceType);
+
+    PrefixMapper.INSTANCE.updateRequestToPrefix(prefixDto, prefix);
 
     // update the prefix
     prefix.setService(service);

--- a/api/src/main/resources/db/migration/V1.8__update_contract_end_prefix.sql
+++ b/api/src/main/resources/db/migration/V1.8__update_contract_end_prefix.sql
@@ -1,0 +1,9 @@
+-- ------------------------------------------------
+-- Version: v1.8
+--
+-- Description: Add column contract_end to prefix
+-- -------------------------------------------------
+
+ALTER TABLE prefix
+ADD COLUMN contract_end TIMESTAMP;
+

--- a/api/src/test/java/gr/grnet/pccapi/PrefixEndpointTest.java
+++ b/api/src/test/java/gr/grnet/pccapi/PrefixEndpointTest.java
@@ -59,7 +59,8 @@ public class PrefixEndpointTest {
             .setServiceId(1)
             .setProviderId(1)
             .setContactEmail("test@test.com")
-            .setContactName("testname");
+            .setContactName("testname")
+            .setContractEnd("2008-01-01T00:00:00Z");
 
     var response =
         given()
@@ -87,6 +88,7 @@ public class PrefixEndpointTest {
     assertEquals(Boolean.TRUE, response.getResolvable());
     assertEquals("test@test.com", response.getContactEmail());
     assertEquals("testname", response.getContactName());
+    assertEquals("2008-01-01T00:00:00Z", response.getContractEnd());
   }
 
   @Test
@@ -101,7 +103,8 @@ public class PrefixEndpointTest {
             .setLookUpServiceType(String.valueOf(LookUpServiceType.PRIVATE))
             .setDomainId(1)
             .setServiceId(1)
-            .setProviderId(1);
+            .setProviderId(1)
+            .setContractEnd("2008-01-01T00:00:00Z");
 
     // create the prefix
     given().contentType(ContentType.JSON).body(requestBody).post();
@@ -132,7 +135,8 @@ public class PrefixEndpointTest {
             .setDomainId(1)
             .setServiceId(999)
             .setProviderId(1)
-            .setLookUpServiceType(String.valueOf(LookUpServiceType.PRIVATE));
+            .setLookUpServiceType(String.valueOf(LookUpServiceType.PRIVATE))
+            .setContractEnd("2008-01-01T00:00:00Z");
 
     var response =
         given()
@@ -160,7 +164,8 @@ public class PrefixEndpointTest {
             .setDomainId(999)
             .setServiceId(1)
             .setProviderId(1)
-            .setLookUpServiceType(String.valueOf(LookUpServiceType.PRIVATE));
+            .setLookUpServiceType(String.valueOf(LookUpServiceType.PRIVATE))
+            .setContractEnd("2008-01-01T00:00:00Z");
 
     var response =
         given()
@@ -188,7 +193,8 @@ public class PrefixEndpointTest {
             .setDomainId(1)
             .setServiceId(1)
             .setProviderId(999)
-            .setLookUpServiceType(String.valueOf(LookUpServiceType.PRIVATE));
+            .setLookUpServiceType(String.valueOf(LookUpServiceType.PRIVATE))
+            .setContractEnd("2008-01-01T00:00:00Z");
 
     var response =
         given()
@@ -216,7 +222,8 @@ public class PrefixEndpointTest {
             .setDomainId(1)
             .setServiceId(1)
             .setProviderId(1)
-            .setResolvable(Boolean.TRUE);
+            .setResolvable(Boolean.TRUE)
+            .setContractEnd("2008-01-01T00:00:00Z");
 
     var resp =
         given()
@@ -241,7 +248,8 @@ public class PrefixEndpointTest {
             .setProviderId(2)
             .setResolvable(Boolean.FALSE)
             .setContactEmail("test2@test.com")
-            .setContactName("testname2");
+            .setContactName("testname2")
+            .setContractEnd("2018-01-01T00:00:00Z");
 
     var response =
         given()
@@ -267,6 +275,7 @@ public class PrefixEndpointTest {
     assertEquals(Boolean.FALSE, response.getResolvable());
     assertEquals("testname2", response.getContactName());
     assertEquals("test2@test.com", response.getContactEmail());
+    assertEquals("2018-01-01T00:00:00Z", response.getContractEnd());
   }
 
   @Test
@@ -282,7 +291,8 @@ public class PrefixEndpointTest {
             .setLookUpServiceType(String.valueOf(LookUpServiceType.PRIVATE))
             .setDomainId(1)
             .setServiceId(1)
-            .setProviderId(1);
+            .setProviderId(1)
+            .setContractEnd("2008-01-01T00:00:00Z");
 
     var response =
         given()
@@ -320,7 +330,8 @@ public class PrefixEndpointTest {
             .setLookUpServiceType(String.valueOf(LookUpServiceType.PRIVATE))
             .setDomainId(1)
             .setServiceId(1)
-            .setProviderId(1);
+            .setProviderId(1)
+            .setContractEnd("2008-01-01T00:00:00Z");
 
     var response =
         given()
@@ -351,7 +362,8 @@ public class PrefixEndpointTest {
             .setLookUpServiceType(String.valueOf(LookUpServiceType.PRIVATE))
             .setDomainId(1)
             .setServiceId(1)
-            .setProviderId(1);
+            .setProviderId(1)
+            .setContractEnd("2008-01-01T00:00:00Z");
 
     var response =
         given()
@@ -390,7 +402,8 @@ public class PrefixEndpointTest {
             .setLookUpServiceType(String.valueOf(LookUpServiceType.BOTH))
             .setDomainId(1)
             .setServiceId(1)
-            .setProviderId(1);
+            .setProviderId(1)
+            .setContractEnd("2008-01-01T00:00:00Z");
 
     var created =
         given()
@@ -416,6 +429,7 @@ public class PrefixEndpointTest {
     assertEquals(created.domainId, prefixResponseDto.domainId);
     assertEquals(created.id, prefixResponseDto.id);
     assertEquals(created.lookUpServiceType, prefixResponseDto.lookUpServiceType);
+    assertEquals("2008-01-01T00:00:00Z", prefixResponseDto.contractEnd);
   }
 
   @Test
@@ -491,7 +505,8 @@ public class PrefixEndpointTest {
             .setProviderId(1)
             .setResolvable(Boolean.TRUE)
             .setContactName("testname")
-            .setContactEmail("test@test.com");
+            .setContactEmail("test@test.com")
+            .setContractEnd("2008-01-01T00:00:00Z");
 
     var response =
         given()
@@ -511,8 +526,8 @@ public class PrefixEndpointTest {
             .setDomainId(2)
             .setResolvable(Boolean.FALSE)
             .setContactEmail("test2@test.com")
-            .setContactName("testname2");
-
+            .setContactName("testname2")
+            .setContractEnd("2018-01-01T00:00:00Z");
     var patchResponse =
         given()
             .contentType(ContentType.JSON)
@@ -530,6 +545,7 @@ public class PrefixEndpointTest {
     assertEquals(patchRequestBody.resolvable, patchResponse.resolvable);
     assertEquals(patchRequestBody.contactEmail, patchResponse.contactEmail);
     assertEquals(patchRequestBody.contactName, patchResponse.contactName);
+    assertEquals(patchRequestBody.contractEnd, patchResponse.contractEnd);
   }
 
   @Test
@@ -544,7 +560,8 @@ public class PrefixEndpointTest {
             .setLookUpServiceType(String.valueOf(LookUpServiceType.PRIVATE))
             .setDomainId(1)
             .setServiceId(1)
-            .setProviderId(1);
+            .setProviderId(1)
+            .setContractEnd("2018-01-01T00:00:00Z");
 
     var response =
         given()
@@ -586,7 +603,8 @@ public class PrefixEndpointTest {
             .setLookUpServiceType(String.valueOf(LookUpServiceType.PRIVATE))
             .setDomainId(1)
             .setServiceId(1)
-            .setProviderId(1);
+            .setProviderId(1)
+            .setContractEnd("2018-01-01T00:00:00Z");
 
     var response =
         given()


### PR DESCRIPTION
contract_end field added to prefix. it is of type timestamp. in the request , in the dto the field is given as a string of type "yyyy-MM-dd'T'HH:mm:ss'Z'" and is received from the response dto on the same type 