### PR TITLE
PCC-107 Add resolvable in the prefix

### DIFF
--- a/api/src/main/java/gr/grnet/pccapi/dto/PartialPrefixDto.java
+++ b/api/src/main/java/gr/grnet/pccapi/dto/PartialPrefixDto.java
@@ -54,4 +54,7 @@ public class PartialPrefixDto {
       example = "1")
   @JsonProperty("provider_id")
   public Integer providerId;
+
+  @JsonProperty("resolvable")
+  public Boolean resolvable = Boolean.TRUE;
 }

--- a/api/src/main/java/gr/grnet/pccapi/dto/PrefixDto.java
+++ b/api/src/main/java/gr/grnet/pccapi/dto/PrefixDto.java
@@ -57,4 +57,7 @@ public class PrefixDto {
       example = "1")
   @JsonProperty("provider_id")
   public Integer providerId;
+
+  @JsonProperty("resolvable")
+  public Boolean resolvable = Boolean.TRUE;
 }

--- a/api/src/main/java/gr/grnet/pccapi/entity/Prefix.java
+++ b/api/src/main/java/gr/grnet/pccapi/entity/Prefix.java
@@ -48,4 +48,6 @@ public class Prefix extends PanacheEntityBase {
   @ManyToOne()
   @JoinColumn(name = "provider_id")
   public Provider provider;
+
+  public Boolean resolvable;
 }

--- a/api/src/main/java/gr/grnet/pccapi/service/PrefixService.java
+++ b/api/src/main/java/gr/grnet/pccapi/service/PrefixService.java
@@ -71,7 +71,8 @@ public class PrefixService {
             .setOwner(prefixDto.getOwner())
             .setName(prefixDto.getName())
             .setUsedBy(prefixDto.getUsedBy())
-            .setStatus(prefixDto.getStatus());
+            .setStatus(prefixDto.getStatus())
+            .setResolvable(prefixDto.getResolvable());
 
     prefixRepository.persist(prefix);
     return PrefixMapper.INSTANCE.prefixToResponseDto(prefix);
@@ -207,6 +208,7 @@ public class PrefixService {
     prefix.setOwner(prefixDto.owner);
     prefix.setUsedBy(prefixDto.usedBy);
     prefix.setName(prefixDto.name);
+    prefix.setResolvable(prefixDto.resolvable);
 
     return PrefixMapper.INSTANCE.prefixToResponseDto(prefix);
   }

--- a/api/src/main/resources/db/migration/V1.6__update_prefix.sql
+++ b/api/src/main/resources/db/migration/V1.6__update_prefix.sql
@@ -1,0 +1,8 @@
+-- ------------------------------------------------
+-- Version: v1.6
+--
+-- Description: Add column resolvable (boolean) to prefixes
+-- -------------------------------------------------
+
+ALTER TABLE prefix
+ADD resolvable  BOOLEAN DEFAULT TRUE;

--- a/api/src/test/java/gr/grnet/pccapi/PrefixEndpointTest.java
+++ b/api/src/test/java/gr/grnet/pccapi/PrefixEndpointTest.java
@@ -82,6 +82,7 @@ public class PrefixEndpointTest {
     assertEquals(1, response.getServiceId());
     assertEquals("GRNET", response.getProviderName());
     assertEquals(1, response.getProviderId());
+    assertEquals(Boolean.TRUE, response.getResolvable());
   }
 
   @Test
@@ -210,7 +211,8 @@ public class PrefixEndpointTest {
             .setLookUpServiceType(LookUpServiceType.NONE)
             .setDomainId(1)
             .setServiceId(1)
-            .setProviderId(1);
+            .setProviderId(1)
+            .setResolvable(Boolean.TRUE);
 
     var resp =
         given()
@@ -232,7 +234,8 @@ public class PrefixEndpointTest {
             .setLookUpServiceType(LookUpServiceType.PRIVATE)
             .setDomainId(2)
             .setServiceId(2)
-            .setProviderId(2);
+            .setProviderId(2)
+            .setResolvable(Boolean.FALSE);
 
     var response =
         given()
@@ -255,6 +258,7 @@ public class PrefixEndpointTest {
 
     assertEquals(3, response.getStatus());
     assertEquals("77777", response.getName());
+    assertEquals(Boolean.FALSE, response.getResolvable());
   }
 
   @Test
@@ -476,7 +480,8 @@ public class PrefixEndpointTest {
             .setLookUpServiceType(LookUpServiceType.CENTRAL)
             .setDomainId(1)
             .setServiceId(1)
-            .setProviderId(1);
+            .setProviderId(1)
+            .setResolvable(Boolean.TRUE);
 
     var response =
         given()
@@ -493,7 +498,8 @@ public class PrefixEndpointTest {
         new PartialPrefixDto()
             .setName("222222")
             .setLookUpServiceType(LookUpServiceType.PRIVATE)
-            .setDomainId(2);
+            .setDomainId(2)
+            .setResolvable(Boolean.FALSE);
 
     var patchResponse =
         given()
@@ -509,6 +515,7 @@ public class PrefixEndpointTest {
     assertEquals(patchRequestBody.name, patchResponse.name);
     assertEquals(patchRequestBody.domainId, patchResponse.domainId);
     assertEquals(patchRequestBody.lookUpServiceType, patchResponse.lookUpServiceType);
+    assertEquals(patchRequestBody.resolvable, patchResponse.resolvable);
   }
 
   @Test


### PR DESCRIPTION
resolvable field added to prefix . resolvable is boolean and by default it is true.
sql script added to update the prefix table, and add the column resolvable