### PR TITLE
fix issues during updating prefixes

### DIFF
--- a/api/src/main/java/gr/grnet/pccapi/mapper/PrefixMapper.java
+++ b/api/src/main/java/gr/grnet/pccapi/mapper/PrefixMapper.java
@@ -90,7 +90,7 @@ public interface PrefixMapper {
       target = "contractEnd",
       expression =
           "java(prefixDto.contractEnd != null && StringUtils.isNotEmpty(prefixDto.contractEnd) ? "
-              + "convertToMillis(prefixDto.contractEnd) : null)")
+              + "convertToMillis(prefixDto.contractEnd) : prefix.contractEnd)")
   @Mapping(
       target = "contractType",
       expression =

--- a/api/src/main/java/gr/grnet/pccapi/service/PrefixService.java
+++ b/api/src/main/java/gr/grnet/pccapi/service/PrefixService.java
@@ -114,7 +114,10 @@ public class PrefixService {
 
     // check the uniqueness of the provided name
     if (prefixRepository.existsByName(prefixDto.getName())) {
-      throw new ConflictException("Prefix name already exists");
+      Prefix prefixByName = prefixRepository.findByName(prefixDto.getName());
+      if (prefixByName != null && prefixByName.id != id) {
+        throw new ConflictException("Prefix name already exists");
+      }
     }
 
     PrefixMapper.INSTANCE.updatePrefixFromDto(prefixDto, prefix);
@@ -129,17 +132,21 @@ public class PrefixService {
     }
 
     // check the existence of the provided service and update entity on success
+    Service service = null;
+
     if (prefixDto.getServiceId() != null) {
-      Service service =
+      service =
           serviceRepository
               .findByIdOptional(prefixDto.getServiceId())
               .orElseThrow(() -> new NotFoundException("Service not found"));
-      prefix.setService(service);
     }
+    prefix.setService(service);
 
     // check the existence of the provided domain and update entity on success
+    Domain domain = null;
+
     if (prefixDto.getDomainId() != null) {
-      Domain domain =
+      domain =
           domainRepository
               .findByIdOptional(prefixDto.getDomainId())
               .orElseThrow(() -> new NotFoundException("Domain not found"));
@@ -186,7 +193,10 @@ public class PrefixService {
 
     // check the uniqueness of the provided name
     if (prefixRepository.existsByName(prefixDto.getName())) {
-      throw new ConflictException("Prefix name already exists");
+      Prefix prefixByName = prefixRepository.findByName(prefixDto.getName());
+      if (prefixByName != null && prefixByName.id != id) {
+        throw new ConflictException("Prefix name already exists");
+      }
     }
     var lookUpServiceType =
         PrefixMapper.INSTANCE.validateLookUpServiceType(prefixDto.lookUpServiceType);
@@ -196,22 +206,26 @@ public class PrefixService {
     prefixDto.contractType = String.valueOf(contractType);
 
     PrefixMapper.INSTANCE.updateRequestToPrefix(prefixDto, prefix);
+    Service service = null;
     if (prefixDto.serviceId != null) {
-      Service service =
+      service =
           serviceRepository
               .findByIdOptional(prefixDto.getServiceId())
               .orElseThrow(() -> new NotFoundException("Service not found"));
-      prefix.setService(service);
     }
+    prefix.setService(service);
 
     // check the existence of the provided domain
+    Domain domain = null;
+
     if (prefixDto.domainId != null) {
-      Domain domain =
+      domain =
           domainRepository
               .findByIdOptional(prefixDto.getDomainId())
               .orElseThrow(() -> new NotFoundException("Domain not found"));
-      prefix.setDomain(domain);
     }
+    prefix.setDomain(domain);
+
     // update the prefix
     prefix.setProvider(provider);
 


### PR DESCRIPTION
some fixes happend to update/partial update of prefixes. 
to pass null values for service_id, domain_id,during update
to permit to update when the name value remains the same-not being updated.
fix contract_end during partial update. contract_end if not defined was declared null. fixed to keep the previous value of the property